### PR TITLE
games/GROVE: Remove FA release page

### DIFF
--- a/games/GROVE.yaml
+++ b/games/GROVE.yaml
@@ -63,7 +63,6 @@ tags:
     - linux
 
 links:
-    uri: https://www.furaffinity.net/view/43181625/
   - name: .itch.io
     uri: https://grovedev.itch.io/groverpgnsfw
   - name: .unofficial-version-zh

--- a/games/GROVE.yaml
+++ b/games/GROVE.yaml
@@ -63,8 +63,6 @@ tags:
     - linux
 
 links:
-  - name: .release-page
-    icon: furaffinity
     uri: https://www.furaffinity.net/view/43181625/
   - name: .itch.io
     uri: https://grovedev.itch.io/groverpgnsfw


### PR DESCRIPTION
FA page now requests that users visit the itch.io page