### PR TITLE
README: change to directory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ The motive for creating this project was that Lucky Doge gave up his Furry Game 
 
 Select languages:
 
-- [English](#about-this-project)
+- [English](#English)
 - [简体中文](#Simplified_Chinese)
 - [繁體中文](#Traditional_Chinese)
 

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Select languages:
 
 1. [游戏数据文件](doc/contribute_guide/game.zh-cn.md)
    - [标签](doc/tags.zh-cn.md)
-2. 作者数据文件
+2. [作者数据文件](doc/contribute_guide/author.zh-cn.md)
 3. [提交补丁的注意事项](doc/contribute_guide/patches-submitting.zh-cn.md)
 
 <a id="Traditional_Chinese">

--- a/README.md
+++ b/README.md
@@ -1,7 +1,56 @@
 # Furry Games Index
 
+The motive for creating this project was that Lucky Doge gave up his Furry Game Collection project, and Utopic Panther once benefited from the project of Lucky Doge, and trying to rebuild a game collection on the Internet. Lucky Doge generously provided the results that he had made a lot of hard work, making it possible for this project to quickly develop into a practical list. The project pays more attention to maintainability, encourages community participation, provides convenient infrastructure for community participation and improves ease of use (such as tagging and search functions), and may also do voting and discussion in the future.
+
+## Document Directory
+
 Select languages:
 
-- [English](README.en.md)
-- [简体中文](README.zh-cn.md)
-- [繁體中文](README.zh-tw.md)
+- [English](#about-this-project)
+- [简体中文](#Simplified_Chinese)
+- [繁體中文](#Traditional_Chinese)
+
+<a id="English">
+
+## About This Project
+
+1. [Welcome to The FGI Project](README.en.md)
+2. [Build Guide](BUILD.md)
+
+## [Get Involved](doc/Get-Involved.en.md)
+
+1. [Contribution Guide](doc/Contribute.en.md)
+   - [Tags](doc/tags.en.md)
+2. [FGI Members/Contributors](CONTRIBUTORS.md)
+
+<a id="Simplified_Chinese">
+
+## 关于本项目
+
+1. [欢迎来到 FGI（兽人控游戏索引）项目](README.zh-cn.md)
+2. [构建说明](BUILD.md)
+
+## [参与其中](doc/Get-Involved.zh-cn.md)
+
+### [贡献指南](doc/Contribute.zh-cn.md)
+
+1. [游戏数据文件](doc/contribute_guide/game.zh-cn.md)
+   - [标签](doc/tags.zh-cn.md)
+2. 作者数据文件
+3. [提交补丁的注意事项](doc/contribute_guide/patches-submitting.zh-cn.md)
+
+<a id="Traditional_Chinese">
+
+## 關於此專案
+
+1. [歡迎來到 FGI（獸人控遊戲索引）專案](README.zh-tw.md)
+2. [構建說明](BUILD.md)
+
+## [參與其中](Get-Involved.zh-tw.md)
+
+### [貢獻指南](doc/Contribute.zh-tw.md)
+
+1. [遊戲資料檔案](doc/contribute_guide/game.zh-tw.md)
+   - [標籤](doc/tags.zh-tw.md)
+2. 作者資料檔案
+3. [提交補丁的注意事項](doc/contribute_guide/patches-submitting.zh-tw.md)

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 The motive for creating this project was that Lucky Doge gave up his Furry Game Collection project, and Utopic Panther once benefited from the project of Lucky Doge, and trying to rebuild a game collection on the Internet. Lucky Doge generously provided the results that he had made a lot of hard work, making it possible for this project to quickly develop into a practical list. The project pays more attention to maintainability, encourages community participation, provides convenient infrastructure for community participation and improves ease of use (such as tagging and search functions), and may also do voting and discussion in the future.
 
+创建该项目的动机是狗哥（LuckyDoge）放弃了他的兽人控游戏合集项目，Utopic Panther 曾经受益于狗哥的项目，试图在互联网上重建一个游戏合集。狗哥慷慨地提供了他曾经付出大量努力取得的成果，使这个项目快速发展为实用的列表成为了可能。该项目更加注重可维护性，更加鼓励社区参与，为社区参与提供便利的基础设施和提高易用性（如标签及搜索功能），未来可能还会做评分和讨论功能。
+
 ## Document Directory
 
 Select languages:


### PR DESCRIPTION
重写了项目首页的 README，以便贡献者能够直接跳转到对应的文档，而不是层层点击超链接跳转。对于其他人也能迅速对本项目有个大概的认识。