### PR TITLE
games/Adastra: update links

### DIFF
--- a/games/Adastra.yaml
+++ b/games/Adastra.yaml
@@ -66,8 +66,8 @@ links:
     icon: twitter
     uri: https://twitter.com/ABLocalization/status/1272934863977345025
   - name: .unofficial-patch-zh
-    icon: weibo
-    uri: https://weibo.com/7429628292/J6V5SACH8
+    icon: telegram
+    uri: https://t.me/AuroraBorealisCN
 
 thumbnail: thumbnail.jpg
 

--- a/games/Arches.yaml
+++ b/games/Arches.yaml
@@ -62,8 +62,8 @@ links:
     icon: twitter
     uri: https://twitter.com/ABLocalization/status/1396757517191966720
   - name: .unofficial-patch-zh
-    icon: weibo
-    uri: https://weibo.com/7429628292/KgYGxFmH6
+    icon: telegram
+    uri: https://t.me/AuroraBorealisCN
 
 thumbnail: thumbnail.jpg
 

--- a/games/Interea.yaml
+++ b/games/Interea.yaml
@@ -56,9 +56,9 @@ links:
     uri: patreon:EchoGame
   - name: .twitter
     uri: twitter:EchoTheVN
-  - name: .unofficial-version-zh
-    icon: weibo
-    uri: https://weibo.com/7429628292/KneSjEnX4
+  - name: .unofficial-patch-zh
+    icon: telegram
+    uri: https://t.me/AuroraBorealisCN
 
 thumbnail: thumbnail.jpg
 

--- a/games/Smoke_Room_Christmas.yaml
+++ b/games/Smoke_Room_Christmas.yaml
@@ -4,49 +4,27 @@ description: |
   Hey folks. George here. Happy Holidays!  Have a surprise build as a holiday gift from us to you!
   
   This is an AU version of the smoke room in the modern day. Hope y'all have as much fun reading it as we did writing it. 
-
-  
   
   And now: a poem from Nick:
-  
   Twas the night before Christmas and all through the house,
-  
   Not a creature was stirring (on account they were soused),
-  
   The stockings were scattered through rooms here and there,
-  
   As our Christmas Eve clients need more hurry than care
-  
   We harlots were nestled all snug in our beds
-  
   As visions of †̷͒˙̶̅´̴͊µ̶̓ danced in our heads
-  
   And Cyn in her bonnet and I in my cap,
-  
   Had settled our heads for a long winter’s nap
-  
   When out on the porch there arose such a clatter
-  
   I fell out of bed, “what the fuck is the matter?”
-  
   To the window I shuffled, feeling like trash,
-  
   If ‘twere drunk Reed again, to give him a smash.
-  
   And the moon on cold dirt, appearing like snow,
-  
   Gave a luster like midday to all things below
-  
   When what into my hungover eyes did then spring,
-  
   But a miniature sleigh and eight tiny ducklings.
-  
   With the brawniest driver, so lively and thick
-  
   I knew in a moment it must be St. Nik! 
-  
   “Now, Donald! Now, Daisy! Now Daffy and Huey!
-  
   Now, Aflac! Now, Launchpad! Now Howard and Louie!”
 
 authors:
@@ -107,6 +85,9 @@ links:
   - name: .unofficial-version-zh
     icon: twitter
     uri: https://twitter.com/ABLocalization/status/1476838888425484288
+  - name: .unofficial-patch-zh
+    icon: telegram
+    uri: https://t.me/AuroraBorealisCN
 
 thumbnail: thumbnail.jpg
 

--- a/games/The_Smoke_Room.yaml
+++ b/games/The_Smoke_Room.yaml
@@ -56,8 +56,8 @@ links:
     icon: twitter
     uri: https://twitter.com/ABLocalization/status/1396739006147088388
   - name: .unofficial-patch-zh
-    icon: weibo
-    uri: https://weibo.com/7429628292/K4FlxaCrD
+    icon: telegram
+    uri: https://t.me/AuroraBorealisCN
 
 thumbnail: thumbnail.jpg
 


### PR DESCRIPTION
微博已经基本弃用，下载链接用汉化组Telegram替代