### PR TITLE
uil10n: Add PlayStation Translations

### DIFF
--- a/uil10n/en.yaml
+++ b/uil10n/en.yaml
@@ -92,6 +92,17 @@ preferences_steam_widget_tip: If possible, the Steam Store Widget will be displa
 rss_desc: RSS Feed will push the 50 most recent game entries added to FGI in chronological order.
 
 stock-link-website: Official Website
+stock-link-twitter: Official Twitter
+stock-link-furaffinity: Official FurAffinity
+stock-link-deviantart: Official DeviantART
+stock-link-patreon: Patreon
+stock-link-weibo: Official Weibo
+stock-link-tumblr: Official Tumblr
+stock-link-pixiv: Official Pixiv
+stock-link-discord: Official Discord
+stock-link-youtube: Official YouTube
+stock-link-facebook: Official Facebook
+
 stock-link-release-page: Release page
 stock-link-play-on-web: Play on Web
 stock-link-steam: Get on Steam
@@ -106,16 +117,7 @@ stock-link-nintendo-e-shop: Get on Nintendo eShop
 stock-link-playstation-store: Get on PlayStation Store
 stock-link-gog.com: Get on GOG.com
 stock-link-microsoft-store: Get on Microsoft Store
-stock-link-twitter: Official Twitter
-stock-link-furaffinity: Official FurAffinity
-stock-link-deviantart: Official DeviantART
-stock-link-patreon: Patreon
-stock-link-weibo: Official Weibo
-stock-link-tumblr: Official Tumblr
-stock-link-pixiv: Official Pixiv
-stock-link-discord: Official Discord
-stock-link-youtube: Official YouTube
-stock-link-facebook: Official Facebook
+
 stock-link-unofficial-patch-en: Unofficial English patch
 stock-link-unofficial-version-en: Unofficial English version
 stock-link-unofficial-patch-zh: Unofficial Chinese patch

--- a/uil10n/zh-cn.yaml
+++ b/uil10n/zh-cn.yaml
@@ -91,6 +91,16 @@ preferences_steam_widget_tip: 如果可能的话，将在游戏页面上显示 S
 rss_desc: RSS Feed 将以时间顺序推送最近添加到 FGI 的 50 个游戏条目。
 
 stock-link-website: 官方网站
+stock-link-twitter: 官方 Twitter
+stock-link-furaffinity: 官方 FurAffinity
+stock-link-deviantart: 官方 DeviantART
+stock-link-weibo: 官方微博
+stock-link-tumblr: 官方 Tumblr
+stock-link-pixiv: 官方 Pixiv
+stock-link-discord: 官方 Discord
+stock-link-youtube: 官方 YouTube
+stock-link-facebook: 官方 Facebook
+
 stock-link-release-page: 发布页面
 stock-link-play-on-web: 在 Web 浏览器中游玩
 stock-link-steam: 在 Steam 上获取
@@ -103,16 +113,9 @@ stock-link-play-store: 在 Google Play 上获取
 stock-link-apple-appstore: 在 App Store 上获取
 stock-link-nintendo-e-shop: 在 Nintendo eShop 上获取
 stock-link-gog.com: 在 GOG.com 上获取
+stock-link-playstation-store: 在 PlayStation Store 上获取
 stock-link-microsoft-store: 在 Microsoft Store 上获取
-stock-link-twitter: 官方 Twitter
-stock-link-furaffinity: 官方 FurAffinity
-stock-link-deviantart: 官方 DeviantART
-stock-link-weibo: 官方微博
-stock-link-tumblr: 官方 Tumblr
-stock-link-pixiv: 官方 Pixiv
-stock-link-discord: 官方 Discord
-stock-link-youtube: 官方 YouTube
-stock-link-facebook: 官方 Facebook
+
 stock-link-unofficial-patch-zh: 非官方中文补丁
 stock-link-unofficial-version-zh: 非官方中文版本
 stock-link-demo-version: 获取演示版本

--- a/uil10n/zh-tw.yaml
+++ b/uil10n/zh-tw.yaml
@@ -91,6 +91,16 @@ preferences_steam_widget_tip: 如果可能的話，將在遊戲頁面上顯示 S
 rss_desc: RSS Feed 將以時間順序推送最近新增到 FGI 的 50 個遊戲條目。
 
 stock-link-website: 官方網站
+stock-link-twitter: 官方 Twitter
+stock-link-furaffinity: 官方 FurAffinity
+stock-link-deviantart: 官方 DeviantART
+stock-link-weibo: 官方微博
+stock-link-tumblr: 官方 Tumblr
+stock-link-pixiv: 官方 Pixiv
+stock-link-discord: 官方 Discord
+stock-link-youtube: 官方 YouTube
+stock-link-facebook: 官方 Facebook
+
 stock-link-release-page: 釋出頁面
 stock-link-play-on-web: 在 Web 瀏覽器中游玩
 stock-link-steam: 在 Steam 上獲取
@@ -103,16 +113,9 @@ stock-link-play-store: 在 Google Play 上獲取
 stock-link-apple-appstore: 在 App Store 上獲取
 stock-link-nintendo-e-shop: 在 Nintendo eShop 上獲取
 stock-link-gog.com: 在 GOG.com 上獲取
+stock-link-playstation-store: 在 PlayStation Store 上獲取
 stock-link-microsoft-store: 在 Microsoft Store 上獲取
-stock-link-twitter: 官方 Twitter
-stock-link-furaffinity: 官方 FurAffinity
-stock-link-deviantart: 官方 DeviantART
-stock-link-weibo: 官方微博
-stock-link-tumblr: 官方 Tumblr
-stock-link-pixiv: 官方 Pixiv
-stock-link-discord: 官方 Discord
-stock-link-youtube: 官方 YouTube
-stock-link-facebook: 官方 Facebook
+
 stock-link-unofficial-patch-zh: 非官方中文補丁
 stock-link-unofficial-version-zh: 非官方中文版本
 stock-link-demo-version: 獲取演示版本


### PR DESCRIPTION
添加 PS Store 的翻译
调整网站排序，社交网站在前，发布网站在后